### PR TITLE
Added defusedxml to address runtime dependency in roslaunch

### DIFF
--- a/licenses/PSFL
+++ b/licenses/PSFL
@@ -1,0 +1,49 @@
+PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+--------------------------------------------
+
+1. This LICENSE AGREEMENT is between the Python Software Foundation
+("PSF"), and the Individual or Organization ("Licensee") accessing and
+otherwise using this software ("Python") in source or binary form and
+its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, PSF
+hereby grants Licensee a nonexclusive, royalty-free, world-wide
+license to reproduce, analyze, test, perform and/or display publicly,
+prepare derivative works, distribute, and otherwise use Python
+alone or in any derivative version, provided, however, that PSF's
+License Agreement and PSF's notice of copyright, i.e., "Copyright (c)
+2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008 Python Software Foundation; 
+All Rights Reserved" are retained in Python alone or in any derivative 
+version prepared by Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python.
+
+4. PSF is making Python available to Licensee on an "AS IS"
+basis.  PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any
+relationship of agency, partnership, or joint venture between PSF and
+Licensee.  This License Agreement does not grant permission to use PSF
+trademarks or trade name in a trademark sense to endorse or promote
+products or services of Licensee, or any third party.
+
+8. By copying, installing or otherwise using Python, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.
+

--- a/recipes-devtools/python/python-defusedxml.inc
+++ b/recipes-devtools/python/python-defusedxml.inc
@@ -1,0 +1,11 @@
+DESCRIPTION = "XML bomb protection for Python stdlib modules"
+SECTION = "devel/python"
+LICENSE = "PSFL"
+LIC_FILES_CHKSUM = "file://PKG-INFO;beginline=8;endline=8;md5=a560e172e996ab553d352ccff41c7d20"
+SRCNAME = "defusedxml"
+
+SRC_URI = "http://pypi.python.org/packages/source/d/defusedxml/defusedxml-${PV}.tar.gz"
+SRC_URI[md5sum] = "230a5eff64f878b392478e30376d673a"
+SRC_URI[sha256sum] = "cd551d5a518b745407635bb85116eb813818ecaf182e773c35b36239fc3f2478"
+
+S = "${WORKDIR}/${SRCNAME}-${PV}"

--- a/recipes-devtools/python/python-defusedxml_0.4.1.bb
+++ b/recipes-devtools/python/python-defusedxml_0.4.1.bb
@@ -1,0 +1,13 @@
+DESCRIPTION = "XML bomb protection for Python stdlib modules"
+SECTION = "devel/python"
+LICENSE = "PSFL"
+LIC_FILES_CHKSUM = "file://PKG-INFO;beginline=8;endline=8;md5=a560e172e996ab553d352ccff41c7d20"
+SRCNAME = "defusedxml"
+
+SRC_URI = "http://pypi.python.org/packages/source/d/defusedxml/defusedxml-${PV}.tar.gz"
+SRC_URI[md5sum] = "230a5eff64f878b392478e30376d673a"
+SRC_URI[sha256sum] = "cd551d5a518b745407635bb85116eb813818ecaf182e773c35b36239fc3f2478"
+
+S = "${WORKDIR}/${SRCNAME}-${PV}"
+
+inherit setuptools

--- a/recipes-devtools/python/python3-defusedxml_0.4.1.bb
+++ b/recipes-devtools/python/python3-defusedxml_0.4.1.bb
@@ -1,3 +1,3 @@
 require python-defusedxml.inc
 
-inherit setuptools
+inherit setuptools3

--- a/recipes-ros/ros-comm/roslaunch_1.12.7.bb
+++ b/recipes-ros/ros-comm/roslaunch_1.12.7.bb
@@ -22,7 +22,7 @@ RDEPENDS_${PN} = "\
     ${PYTHON_PN}-rospkg \
     rosgraph \
     ${PYTHON_PN}-pyyaml \
-    python-defusedxml \
+    ${PYTHON_PN}-defusedxml \
     roslib \
     rosclean \
     rosmaster \

--- a/recipes-ros/ros-comm/roslaunch_1.12.7.bb
+++ b/recipes-ros/ros-comm/roslaunch_1.12.7.bb
@@ -22,6 +22,7 @@ RDEPENDS_${PN} = "\
     ${PYTHON_PN}-rospkg \
     rosgraph \
     ${PYTHON_PN}-pyyaml \
+    python-defusedxml \
     roslib \
     rosclean \
     rosmaster \


### PR DESCRIPTION
Cherry-picked commit from kinetic-experimental with added compatibility for python3.

The testing I did:
- bitbake roslaunch
- bitbake python-defusedxml
- bitbake python3-defusedxml
- Used similar patches in my own layer and did a runtime test with roslaunch and python2