### PR TITLE
geographic info

### DIFF
--- a/recipes-devtools/python/python-pyproj.inc
+++ b/recipes-devtools/python/python-pyproj.inc
@@ -1,0 +1,14 @@
+DESCRIPTION = "Python interface to PROJ.4 library"
+SECTION = "devel/python"
+LICENSE = "ISC & MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=77d9726a341183ab262b28b3d66dfd94 \
+                    file://LICENSE_proj4;md5=74d9aaec5fa0cd734341e8c4dc91b608"
+SRCNAME = "pyproj"
+
+SRC_URI = "http://pypi.python.org/packages/source/p/pyproj/pyproj-${PV}.tar.gz"
+SRC_URI[md5sum] = "027345e3c033fa400e0e64a1c80d34c9"
+SRC_URI[sha256sum] = "53fa54c8fa8a1dfcd6af4bf09ce1aae5d4d949da63b90570ac5ec849efaf3ea8"
+
+RDEPENDS_${PN} = "proj"
+
+S = "${WORKDIR}/${SRCNAME}-${PV}"

--- a/recipes-devtools/python/python-pyproj.inc
+++ b/recipes-devtools/python/python-pyproj.inc
@@ -9,6 +9,4 @@ SRC_URI = "http://pypi.python.org/packages/source/p/pyproj/pyproj-${PV}.tar.gz"
 SRC_URI[md5sum] = "027345e3c033fa400e0e64a1c80d34c9"
 SRC_URI[sha256sum] = "53fa54c8fa8a1dfcd6af4bf09ce1aae5d4d949da63b90570ac5ec849efaf3ea8"
 
-RDEPENDS_${PN} = "proj"
-
 S = "${WORKDIR}/${SRCNAME}-${PV}"

--- a/recipes-devtools/python/python-pyproj_1.9.5.1.bb
+++ b/recipes-devtools/python/python-pyproj_1.9.5.1.bb
@@ -1,0 +1,3 @@
+include python-pyproj.inc
+
+inherit setuptools

--- a/recipes-devtools/python/python3-pyproj_1.9.5.1.bb
+++ b/recipes-devtools/python/python3-pyproj_1.9.5.1.bb
@@ -1,0 +1,3 @@
+include python-pyproj.inc
+
+inherit setuptools3

--- a/recipes-ros/geographic-info/geodesy_0.5.2.bb
+++ b/recipes-ros/geographic-info/geodesy_0.5.2.bb
@@ -3,6 +3,7 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "python-pyproj tf"
+DEPENDS = "tf geographic-msgs unique-id"
+RDEPENDS_${PN} = "python-pyproj tf geographic-msgs unique-id"
 
 require geographic-info.inc

--- a/recipes-ros/geographic-info/geodesy_0.5.2.bb
+++ b/recipes-ros/geographic-info/geodesy_0.5.2.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Python and C++ interfaces for manipulating geodetic coordinates."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "python-pyproj tf"
+
+require geographic-info.inc

--- a/recipes-ros/geographic-info/geographic-info.inc
+++ b/recipes-ros/geographic-info/geographic-info.inc
@@ -1,0 +1,11 @@
+SRC_URI = "https://github.com/ros-geographic-info/${ROS_SPN}/archive/${ROS_SP}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "8c269b49460b47655c7d3d8e090d5355"
+SRC_URI[sha256sum] = "8e5a6b8c63aae9d97a511034536c295f4229e93cc40e60988464dfc591f8564b"
+
+DEPENDS += "cpp-common roscpp-serialization message-generation message-runtime std-msgs uuid-msgs geometry-msgs"
+
+S = "${WORKDIR}/${ROS_SPN}-${ROS_SP}/${ROS_BPN}"
+
+inherit catkin
+
+ROS_SPN = "geographic_info"

--- a/recipes-ros/geographic-info/geographic-info_0.5.2.bb
+++ b/recipes-ros/geographic-info/geographic-info_0.5.2.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Geographic information metapackage."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=13;endline=13;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS += "geodesy geographic-msgs"
+
+require geographic-info.inc

--- a/recipes-ros/geographic-info/geographic-msgs_0.5.2.bb
+++ b/recipes-ros/geographic-info/geographic-msgs_0.5.2.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "ROS messages for Geographic Information Systems."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+RDEPENDS_${PN} = "std-msgs uuid-msgs geometry-msgs"
+
+require geographic-info.inc


### PR DESCRIPTION
Added geographic info as well as python-pyproj, which is a dependency og geodesy.

Tested:
- bitbake python-pyproj
- bitbake python3-pyproj
- bitbake geodesy
- bitbake gepgraphic-msgs
- bitbake gepgraphic-info
- python, import pyproj, pyproj.test() runs without errors
- python3, import pyproj, pyproj.test() runs without errors

For the test, runtime dependencies must be installed, but library seems to work without.

I can remove the meta package if it should not be part of this.

I suggest also merging this into other branches.