### PR TITLE
bumping indigo to kinetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This is a layer to provide ROS Indigo Igloo in an OpenEmbedded Linux system.
+This is a layer to provide ROS Kinetic Kame in an OpenEmbedded Linux system.
 It provides a stable cross-compilation build system for many common ROS packages. 
 Currently, this layer is still under continuous development.
 
@@ -190,14 +190,14 @@ resolved in the past.
   to the /etc/hosts file, and set up the environment with
 
     export ROS_ROOT=/opt/ros
-    export ROS_DISTRO=indigo
-    export ROS_PACKAGE_PATH=/opt/ros/indigo/share
-    export PATH=$PATH:/opt/ros/indigo/bin
-    export LD_LIBRARY_PATH=/opt/ros/indigo/lib
-    export PYTHONPATH=/opt/ros/indigo/lib/python2.7/site-packages
+    export ROS_DISTRO=kinetic
+    export ROS_PACKAGE_PATH=/opt/ros/kinetic/share
+    export PATH=$PATH:/opt/ros/kinetic/bin
+    export LD_LIBRARY_PATH=/opt/ros/kinetic/lib
+    export PYTHONPATH=/opt/ros/kinetic/lib/python2.7/site-packages
     export ROS_MASTER_URI=http://localhost:11311
-    export CMAKE_PREFIX_PATH=/opt/ros/indigo
-    touch /opt/ros/indigo/.catkin
+    export CMAKE_PREFIX_PATH=/opt/ros/kinetic
+    touch /opt/ros/kinetic/.catkin
 
   Finally, you can start roscore with
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PRIORITY_ros-layer = "7"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"
 
-ROSDISTRO := "indigo"
+ROSDISTRO := "kinetic"

--- a/lib/recipetool/README.md
+++ b/lib/recipetool/README.md
@@ -28,7 +28,7 @@ These changes are currently in the master branch as of 2017-Aug-24.
 
   ROS repositories generally do not use `master` as their default
   branch, so be sure to include the correct branch for the desired
-  distribution as part of the URI: `<URI>;branch=indigo-devel`
+  distribution as part of the URI: `<URI>;branch=kinetic-devel`
 
 ## EXAMPLES ##
 Build the Vector Nav package

--- a/recipes-ros/ros-comm/roslaunch/roscore-default
+++ b/recipes-ros/ros-comm/roslaunch/roscore-default
@@ -1,9 +1,9 @@
-ROS_ROOT=/opt/ros/indigo/
-ROS_DISTRO=indigo
-ROS_PACKAGE_PATH=/opt/ros/indigo/share
+ROS_ROOT=/opt/ros/kinetic/
+ROS_DISTRO=kinetic
+ROS_PACKAGE_PATH=/opt/ros/kinetic/share
 ROS_PORT=11311
 ROS_MASTER_URI=http://localhost:11311
-CMAKE_PREFIX_PATH=/opt/ros/indigo/
-PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:/opt/ros/indigo/bin
-LD_LIBRARY_PATH=/opt/ros/indigo/lib
-PYTHONPATH=/opt/ros/indigo/lib/python2.7/site-packages
+CMAKE_PREFIX_PATH=/opt/ros/kinetic/
+PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:/opt/ros/kinetic/bin
+LD_LIBRARY_PATH=/opt/ros/kinetic/lib
+PYTHONPATH=/opt/ros/kinetic/lib/python2.7/site-packages

--- a/recipes-ros/ros-comm/roslaunch/roscore.service
+++ b/recipes-ros/ros-comm/roslaunch/roscore.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 EnvironmentFile=/etc/default/roscore
 ExecStartPre=/bin/touch ${CMAKE_PREFIX_PATH}/.catkin
-ExecStart=/opt/ros/indigo/bin/roscore -p $ROS_PORT
+ExecStart=/opt/ros/${ROS_DISTRO}/bin/roscore -p $ROS_PORT
 Restart=on-abort
 
 [Install]


### PR DESCRIPTION
…kinetic"
Hi Lukas,

you requested 3 patches, here comes only one:
The general cleanup indigo -> ${ROSDISTRO} would be empty, as grep-ing for indigo only shows up in instances where it cannot be done (README, or additional config files which are not generated with bitbake. One would need to add an additional build step to generate those, but editing is quicker and in case of errors, easier to track down). 
This pull request holds all changes, that basically move all hardcoded indigos to kinetics...
The last commit regarding bfl: I can change indigo to ${ROSDISTRO}, but I need to also change version from 0.7.0-6 to 0.7.0-2, which looks odd to me. But it seems necessary to build with kinetic... I can commit the patch at any time...

Thanks for your help, 

  Regards Matthias