### PR TITLE
catkin: changed DEPENDS from cmake to cmake-native to fix build error…

### DIFF
--- a/recipes-ros/catkin/catkin.inc
+++ b/recipes-ros/catkin/catkin.inc
@@ -3,7 +3,7 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=7;endline=7;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "cmake ${PYTHON_PN}-empy-native ${PYTHON_PN}-catkin-pkg-native"
+DEPENDS = "cmake-native ${PYTHON_PN}-empy-native ${PYTHON_PN}-catkin-pkg-native"
 
 SRC_URI = "https://github.com/ros/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
 SRC_URI[md5sum] = "f958ca71ba921db6855821de2a6df70c"


### PR DESCRIPTION
… with master/rocko

Hi!

I experienced a build error with rocko / master, build with pyro was unaffected, that clearly indicated that cross compiled binary was called in native context. This hopefully fixes it, tested with rocko /master and pyro.

Regards,

   Matthias