### PR TITLE
feat+fix: addcatkin tools and fix cmake-modules in SDK

### DIFF
--- a/recipes-devtools/python/python-futures_%.bbappend
+++ b/recipes-devtools/python/python-futures_%.bbappend
@@ -1,0 +1,2 @@
+BBCLASSEXTEND = "native nativesdk"
+

--- a/recipes-devtools/python/python-osrf-pycommon_0.1.4.bb
+++ b/recipes-devtools/python/python-osrf-pycommon_0.1.4.bb
@@ -1,0 +1,17 @@
+DESCRIPTION = "Commonly needed Python modules, used by Python software developed at OSRF"
+HOMEPAGE = "https://github.com/osrf/osrf_pycommon"
+SECTION = "devel/python"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=6c4db32a2fa8717faffa1d4f10136f47"
+
+SRCREV = "e32de70e8b42dcd96bb66d29ddfb62e7fd8b795e"
+
+SRCNAME = "osrf_pycommon"
+SRC_URI = "git://github.com/osrf/${SRCNAME}.git"
+
+S = "${WORKDIR}/git"
+
+inherit setuptools
+
+BBCLASSEXTEND = "native nativesdk"
+

--- a/recipes-devtools/python/python-trollius_git.bb
+++ b/recipes-devtools/python/python-trollius_git.bb
@@ -1,0 +1,20 @@
+DESCRIPTION = "Port of the Tulip project (asyncio module, PEP 3156) on Python 2"
+HOMEPAGE = "https://github.com/haypo/trollius"
+SECTION = "devel/python"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://COPYING;md5=8f7bb094c7232b058c7e9f2e431f389c"
+
+PV = "2.1+git${SRCPV}"
+SRCREV = "98ba7f856929b8c72920e93c0cf4fe49f510e968"
+
+SRCNAME = "trollius"
+SRC_URI = "git://github.com/haypo/${SRCNAME}.git;branch=trollius"
+
+S = "${WORKDIR}/git"
+
+inherit setuptools
+
+RDEPENDS_${PN} = "python-futures python-six"
+
+BBCLASSEXTEND = "native nativesdk"
+

--- a/recipes-ros/catkin-tools/catkin-tools_0.4.4.bb
+++ b/recipes-ros/catkin-tools/catkin-tools_0.4.4.bb
@@ -1,0 +1,32 @@
+DESCRIPTION = "Command line tools for working with catkin"
+HOMEPAGE = "http://catkin-tools.readthedocs.io"
+SECTION = "devel/python"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=95183d79271344f1c8ade910eda4deb2"
+
+ROS_SPN = "catkin_tools"
+
+SRC_URI = "https://github.com/catkin/${ROS_SPN}/archive/${PV}.tar.gz"
+SRCREV="a5db715ef4dd9176d079d2a01ae2f7a57f9c9536"
+SRC_URI[md5sum] = "0946b54a708bfd638c936494e94bf7d4"
+SRC_URI[sha256sum] = "5706c971790bca2ee8245b97fe744e4841053588c786ca604d17f81744e8c105"
+
+S = "${WORKDIR}/${ROS_SPN}-${PV}"
+
+RDEPENDS_${PN} = "python-catkin-pkg python-osrf-pycommon python-pyyaml python-trollius"
+RDEPENDS_${PN}_class-nativesdk = "nativesdk-python-setuptools"
+
+FILES_${PN} = " \
+  ${bindir} \
+  ${datadir} \
+  ${sysconfdir} \
+"
+
+inherit setuptools
+
+do_install_append_class-nativesdk () {
+  sed -i 's|${SDKPATHNATIVE}||g' ${D}${bindir}/catkin
+}
+
+BBCLASSEXTEND = "native nativesdk"
+FILES_${PN}_append_class-nativesdk = " ${SDKPATHNATIVE}"

--- a/recipes-ros/cmake-modules/cmake-modules_0.3.3.bb
+++ b/recipes-ros/cmake-modules/cmake-modules_0.3.3.bb
@@ -12,3 +12,6 @@ SRC_URI[sha256sum] = "4f9358aab07cdc5455ee0545e6791a47687b6e5f4b8fe11481c1689681
 S = "${WORKDIR}/${ROS_SP}"
 
 inherit catkin
+
+BBCLASSEXTEND = "native nativesdk"
+


### PR DESCRIPTION
This PR fixes the SDK generation and adds catkin-tools support.
I tried generating an SDK doing

    bitbake <my-custom-image> -c populate_sdk

The nativesdk-cmake-modules package couldn't be found. Hence, the first patch.


Once the SDK was installed on my machine. I could cross compile with catkin_make. Everything was working perfectly.



The second patch adds support to catkin_tools, which is the standard tool to compile ros packages. To make it work, I needed to play with cmake-arguments:

```
catkin build -p $(nproc) -j $(nproc) --cmake-args \
  -DCMAKE_TOOLCHAIN_FILE=$OECORE_NATIVE_SYSROOT/usr/share/cmake/OEToolchainConfig.cmake \
  -DSETUPTOOLS_DEB_LAYOUT=OFF
```

* The `-p $(nproc) -j $(nproc)` is needed since the make job server was not working, allowing to compile only with one core.
* `DCMAKE_TOOLCHAIN_FILE` is self explanatory
* `DSETUPTOOLS_DEB_LAYOUT` Disable debian style python package layout

@bulwahn I would like to simplify it so users won't have to remember those parameters, but I'm not sure how