### PR TITLE
Gcc template patch message filters 

### DIFF
--- a/recipes-ros/ros-comm/message-filters/0001-conforming-template-syntax-for-add.patch
+++ b/recipes-ros/ros-comm/message-filters/0001-conforming-template-syntax-for-add.patch
@@ -1,0 +1,14 @@
+Index: ros_comm-1.12.13/utilities/message_filters/include/message_filters/synchronizer.h
+===================================================================
+--- a/include/message_filters/synchronizer.h
++++ b/include/message_filters/synchronizer.h
+@@ -355,7 +355,7 @@ private:
+   template<int i>
+   void cb(const typename mpl::at_c<Events, i>::type& evt)
+   {
+-    this->add<i>(evt);
++    this->template add<i>(evt);
+   }
+ 
+   uint32_t queue_size_;
+

--- a/recipes-ros/ros-comm/message-filters_1.12.13.bb
+++ b/recipes-ros/ros-comm/message-filters_1.12.13.bb
@@ -7,4 +7,8 @@ DEPENDS = "boost rosconsole roscpp xmlrpcpp"
 
 require ros-comm.inc
 
+SRC_URI += " \
+  file://0001-conforming-template-syntax-for-add.patch \
+"
+
 ROS_PKG_SUBDIR = "utilities"


### PR DESCRIPTION
This patch resolves some errors compiling under GCC 8.x under recent version of yocto under kenetic branches for ros packages