### PR TITLE
Fix check for python2 runtime dependencies

### DIFF
--- a/recipes-ros/catkin/catkin-runtime_0.7.11.bb
+++ b/recipes-ros/catkin/catkin-runtime_0.7.11.bb
@@ -17,7 +17,7 @@ RDEPENDS_${PN}_class-native = ""
 RDEPENDS_${PN} = "\
     ${PYTHON_PN}-catkin-pkg ${PYTHON_PN}-misc ${PYTHON_PN}-multiprocessing \
     ${PYTHON_PN}-shell ${PYTHON_PN}-xml ${PYTHON_PN}-pkgutil \
-    ${@'python-argparse python-subprocess' if d.getVar('PYTHON_PN', True) == 'python2' else ''}"
+    ${@'python-argparse python-subprocess' if d.getVar('PYTHON_PN', True) == 'python' else ''}"
 
 # Delete everything but the python packages in order to avoid
 # that the QA error [installed-vs-shipped] hits on us.

--- a/recipes-ros/ros-comm/roslaunch_1.12.13.bb
+++ b/recipes-ros/ros-comm/roslaunch_1.12.13.bb
@@ -16,7 +16,7 @@ SRC_URI += "file://0001-increase-rosmaster-timeout.patch;patchdir=../.. \
 ROS_PKG_SUBDIR = "tools"
 
 RDEPENDS_${PN} = "\
-    ${@'python-textutils' if d.getVar('PYTHON_PN', True) == 'python2' else ''} \
+    ${@'python-textutils' if d.getVar('PYTHON_PN', True) == 'python' else ''} \
     ${PYTHON_PN}-logging \
     ${PYTHON_PN}-threading \
     ${PYTHON_PN}-rospkg \

--- a/recipes-ros/rospack/rospack_2.4.4.bb
+++ b/recipes-ros/rospack/rospack_2.4.4.bb
@@ -14,4 +14,4 @@ SRC_URI[sha256sum] = "68ff422777dad9e1237d6c774aa7d306bb222bb6ccfc4d1dda6b4124f2
 inherit catkin
 
 RDEPENDS_${PN} = "${PYTHON_PN}-rosdep \
-                  ${@'python-subprocess' if d.getVar('PYTHON_PN', True) == 'python2' else ''}"
+                  ${@'python-subprocess' if d.getVar('PYTHON_PN', True) == 'python' else ''}"


### PR DESCRIPTION
The check for python2 runtime dependencies in https://github.com/bulwahn/meta-ros/commit/bbe1c748394832984de57a43d503678bf94efc16 is faulty, which leads to missing packets on the resulting image.

In indigo this was fixed in:
https://github.com/bmwcarit/meta-ros/commit/c017174e78a347c3bf37186781b2ae516fb64678