### PR TITLE
Add support for custom ros installation prefix

### DIFF
--- a/classes/ros.bbclass
+++ b/classes/ros.bbclass
@@ -1,13 +1,15 @@
 #
 # Copyright (c) 2013 Stefan Herbrechtsmeier, Bielefeld University
-# 
+#
 
 ROS_BPN = "${@d.getVar('BPN', True).replace('-', '_')}"
 
 ROS_SPN ?= "${ROS_BPN}"
 ROS_SP = "${ROS_SPN}-${PV}"
 
-export ros_prefix = "${base_prefix}/opt/ros/${ROSDISTRO}"
+ROS_PREFIX ?= "${base_prefix}/opt/ros/${ROSDISTRO}"
+
+export ros_prefix = "${ROS_PREFIX}"
 
 export ros_bindir = "${ros_prefix}/bin"
 export ros_libdir = "${ros_prefix}/${baselib}"


### PR DESCRIPTION
You can overide the default installation path /opt/ros/${ROSDISTRO} by setting ROS_PREFIX, for
instance in local.conf

This is useful if to get ros to work with other apps that want to own /opt 